### PR TITLE
Orientation crashes

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
@@ -332,10 +332,10 @@ public class RCTCamera {
               camera.stopPreview();
               camera.setDisplayOrientation(displayRotation);
               camera.startPreview();
-          } catch(e) {
-              // at least get the rotation for the error
-              throw new Exception("Debug: rotation " + rotation + " display rotation " + displayRotation, e);
-          }
+        } catch(Exception e) {
+            // at least get the rotation for the error (suspecting rotation is incorrect)
+            throw new RuntimeException("Debug: rotation " + rotation + " display rotation " + displayRotation, e);
+        }
 
         Camera.Parameters parameters = camera.getParameters();
         parameters.setRotation(cameraInfo.rotation);

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
@@ -327,7 +327,15 @@ public class RCTCamera {
         // TODO: take in account the _orientation prop
 
         setAdjustedDeviceOrientation(rotation);
-        camera.setDisplayOrientation(displayRotation);
+
+        try {
+              camera.stopPreview();
+              camera.setDisplayOrientation(displayRotation);
+              camera.startPreview();
+          } catch(e) {
+              // at least get the rotation for the error
+              throw new Exception("Debug: rotation " + rotation + " display rotation " + displayRotation, e);
+          }
 
         Camera.Parameters parameters = camera.getParameters();
         parameters.setRotation(cameraInfo.rotation);


### PR DESCRIPTION
Disable the preview on orientation change. Capture the rotation values on any other error so more information is available.